### PR TITLE
Camera and gimbal improvements

### DIFF
--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1365,7 +1365,9 @@
                   <description>Start image capture sequence</description>
                   <param index="1">Duration between two consecutive pictures (in seconds)</param>
                   <param index="2">Number of images to capture total - 0 for unlimited capture</param>
-                  <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc)</param>
+                  <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
+                  <param index="4">Resolution horizontally (x) in pixels</param>
+                  <param index="5">Resolution horizontally (y) in pixels</param>
               </entry>
 
               <entry value="2001" name="MAV_CMD_IMAGE_STOP_CAPTURE">
@@ -1385,7 +1387,9 @@
                   <description>Starts video capture</description>
                   <param index="1">Camera ID (0 for all cameras), 1 for first, 2 for second, etc.</param>
                   <param index="2">Frames per second</param>
-                  <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc)</param>
+                  <param index="3">Resolution in megapixels (0.3 for 640x480, 1.3 for 1280x720, etc), set to 0 if param 4/5 are used</param>
+                  <param index="4">Resolution horizontally (x) in pixels</param>
+                  <param index="5">Resolution horizontally (y) in pixels</param>
               </entry>
 
               <entry value="2501" name="MAV_CMD_VIDEO_STOP_CAPTURE">

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1045,6 +1045,7 @@
                </entry>
 
                <!-- Camera Controller Mission Commands Enumeration -->
+               <!-- MAV_CMD_DO_DIGICAM_CONFIGURE should be deprecated and replaced with CAMERA_SETTINGS -->
                <entry name="MAV_CMD_DO_DIGICAM_CONFIGURE" value="202">
                    <description>Mission command to configure an on-board camera controller system.</description>
                    <param index="1">Modes: P, TV, AV, M, Etc</param>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1082,12 +1082,12 @@
 
                <entry name="MAV_CMD_DO_MOUNT_CONTROL" value="205">
                    <description>Mission command to control a camera or antenna mount</description>
-                   <param index="1">pitch or lat in degrees, depending on mount mode.</param>
-                   <param index="2">roll or lon in degrees depending on mount mode</param>
-                   <param index="3">yaw or alt (in meters) depending on mount mode</param>
-                   <param index="4">reserved</param>
-                   <param index="5">reserved</param>
-                   <param index="6">reserved</param>
+                   <param index="1">pitch (DEPRECATED: or lat in degrees) depending on mount mode.</param>
+                   <param index="2">roll (DEPRECATED: or lon in degrees) depending on mount mode.</param>
+                   <param index="3">yaw (DEPRECATED: or alt in meters) depending on mount mode.</param>
+                   <param index="4">alt in meters depending on mount mode.</param>
+                   <param index="5">latitude in degrees * 1E7, set if appropriate mount mode.</param>
+                   <param index="6">longitude in degrees * 1E7, set if appropriate mount mode.</param>
                    <param index="7">MAV_MOUNT_MODE enum value</param>
                </entry>
 

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1322,26 +1322,42 @@
                  <param index="2">Camera ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
-               <entry value="523" name="MAV_CMD_SET_CAMERA_SETTINGS">
-                 <description>Set the camera settings (CAMERA_SETTINGS)</description>
+               <entry value="523" name="MAV_CMD_SET_CAMERA_SETTINGS_1">
+                 <description>Set the camera settings part 1 (CAMERA_SETTINGS)</description>
                  <param index="1">Camera ID</param>
-                 <param index="2">Apertue (1/value, NaN for auto)</param>
-                 <param index="3">Shutter speed in s (NaN for auto)</param>
-                 <param index="4">ISO sensitivity (NaN for auto)</param>
-                 <param index="5">White balance (colour temperature in K, NaN for auto)</param>
-                 <param index="6">Reserved for camera mode ID</param>
-                 <param index="7">Reserved for image format ID</param>
+                 <param index="2">Aperture (1/value)</param>
+                 <param index="3">Aperture locked (0: auto, 1: locked)</param>
+                 <param index="4">Shutter speed in s</param>
+                 <param index="5">Shutter speed locked (0: auto, 1: locked)</param>
+                 <param index="6">ISO sensitivity</param>
+                 <param index="7">ISO sensitivity locked (0: auto, 1: locked)</param>
                </entry>
-               <entry value="524" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
+               <entry value="524" name="MAV_CMD_SET_CAMERA_SETTINGS_2">
+                 <description>Set the camera settings part 2 (CAMERA_SETTINGS)</description>
+                 <param index="1">Camera ID</param>
+                 <param index="2">White balance locked (0: auto, 1: locked)</param>
+                 <param index="3">White balance (color temperature in K)</param>
+                 <param index="4">Reserved for camera mode ID</param>
+                 <param index="5">Reserved for color mode ID</param>
+                 <param index="6">Reserved for image format ID</param>
+                 <param index="7">Reserved</param>
+               </entry>
+               <entry value="525" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
                  <description>Request storage information (STORAGE_INFORMATION)</description>
                  <param index="1">1: Request storage information</param>
                  <param index="2">Camera ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
-               <entry value="525" name="MAV_CMD_STORAGE_FORMAT">
+               <entry value="526" name="MAV_CMD_STORAGE_FORMAT">
                  <description>Format a storage medium</description>
                  <param index="1">1: Format storage</param>
                  <param index="2">Storage ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="527" name="MAV_CMD_REQUEST_CAMERA_CAPTURE_STATUS">
+                 <description>Request camera capture status (CAMERA_CAPTURE_STATUS)</description>
+                 <param index="1">1: Request camera capture status</param>
+                 <param index="2">Camera ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
 
@@ -3723,7 +3739,7 @@
 
         <message id="259" name="CAMERA_INFORMATION">
             <description>Information about a camera</description>
-            <field type="uint8_t" name="camera_id">Camera ID if there are multiple.</field>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t[16]" name="vendor_name">Name of the camera vendor</field>
             <field type="uint8_t[16]" name="model_name">Name of the camera model</field>
             <field type="float" name="focal_length">Focal length in mm</field>
@@ -3734,17 +3750,22 @@
         </message>
         <message id="260" name="CAMERA_SETTINGS">
             <description>Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
-            <field type="uint8_t" name="camera_id">Camera ID if there are multiple.</field>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="float" name="aperture">Aperture is 1/value</field>
+            <field type="uint8_t" name="aperture_locked">Aperture locked (0: auto, 1: locked)</field>
             <field type="float" name="shutter_speed">Shutter speed in s</field>
-            <field type="float" name="iso">ISO sensitivity</field>
+            <field type="uint8_t" name="shutter_speed_locked">Shutter speed locked (0: auto, 1: locked)</field>
+            <field type="float" name="iso_sensitivity">ISO sensitivity</field>
+            <field type="uint8_t" name="iso_sensitivity_locked">ISO sensitivity locked (0: auto, 1: locked)</field>
             <field type="float" name="white_balance">Color temperature in K</field>
+            <field type="uint8_t" name="white_balance_locked">Color temperature locked (0: auto, 1: locked)</field>
             <field type="uint8_t" name="mode_id">Reserved for a camera mode ID</field>
+            <field type="uint8_t" name="color_mode_id">Reserved for a color mode ID</field>
             <field type="uint8_t" name="image_format_id">Reserved for image format ID</field>
         </message>
         <message id="261" name="STORAGE_INFORMATION">
             <description>Information about a storage medium</description>
-            <field type="uint8_t" name="storage_id">Storage ID if there are multiple.</field>
+            <field type="uint8_t" name="storage_id">Storage ID if there are multiple</field>
             <field type="uint8_t" name="status">Status of storage (0 not available, 1 unformatted, 2 formatted)</field>
             <field type="float" name="total_capacity">Total capacity in MiB</field>
             <field type="float" name="used_capacity">Used capacity in MiB</field>
@@ -3753,11 +3774,25 @@
             <field type="float" name="write_speed">Write speed in MiB/s</field>
         </message>
         <message id="262" name="CAMERA_CAPTURE_STATUS">
-            <description>Information about a storage medium</description>
-            <field type="uint8_t" name="camera_id">Camera ID if there are multiple.</field>
+            <description>Information about the status of a capture</description>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t" name="image_status">Current status of image capturing (0: no action, 1: capture in progress, 2: capture completed)</field>
             <field type="uint8_t" name="video_status">Current status of video capturing (0: no action, 1: capture in progress, 2: capture completed)</field>
-            <field type="uint8_t[128]" name="file_path">File path of current or last file.</field>
+        </message>
+        <message id="263" name="CAMERA_IMAGE_CAPTURED">
+            <description>Information about a captured image</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+            <field type="uint64_t" name="time_utc">Timestamp (microseconds since UNIX epoch) in UTC. 0 for unknown.</field>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
+            <field type="int32_t" name="lat">Latitude, expressed as degrees * 1E7 where image was taken</field>
+            <field type="int32_t" name="lon">Longitude, expressed as degrees * 1E7 where capture was taken</field>
+            <field type="int32_t" name="alt">Altitude in meters, expressed as * 1E3 (AMSL, not WGS84) where image was taken</field>
+            <field type="int32_t" name="relative_alt">Altitude above ground in meters, expressed as * 1E3 where image was taken</field>
+            <field type="float" name="q1">Quaternion component 1, w (1 in null-rotation) of camera direction</field>
+            <field type="float" name="q2">Quaternion component 2, x (0 in null-rotation) of camera direction</field>
+            <field type="float" name="q3">Quaternion component 3, y (0 in null-rotation) of camera direction</field>
+            <field type="float" name="q4">Quaternion component 4, z (0 in null-rotation) of camera direction</field>
+            <field type="uint8_t[210]" name="file_path">File path of image taken.</field>
         </message>
     </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3777,8 +3777,12 @@
         <message id="262" name="CAMERA_CAPTURE_STATUS">
             <description>Information about the status of a capture</description>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
-            <field type="uint8_t" name="image_status">Current status of image capturing (0: no action, 1: capture in progress, 2: capture completed)</field>
-            <field type="uint8_t" name="video_status">Current status of video capturing (0: no action, 1: capture in progress, 2: capture completed)</field>
+            <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
+            <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
+            <field type="float" name="image_framerate">Image interval capture in Hz</field>
+            <field type="float" name="video_framerate">Video frame rate in Hz</field>
+            <field type="float" name="image_resolution">Resolution in megapixels</field>
+            <field type="float" name="video_resolution">Resolution in megapixels</field>
         </message>
         <message id="263" name="CAMERA_IMAGE_CAPTURED">
             <description>Information about a captured image</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3781,8 +3781,10 @@
             <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
             <field type="float" name="image_interval">Image capture interval in Hz</field>
             <field type="float" name="video_framerate">Video frame rate in Hz</field>
-            <field type="float" name="image_resolution">Resolution in megapixels</field>
-            <field type="float" name="video_resolution">Resolution in megapixels</field>
+            <field type="uint16_t" name="image_resolution_x">Image resolution in pixels horizontally</field>
+            <field type="uint16_t" name="image_resolution_y">Image resolution in pixels vertically</field>
+            <field type="uint16_t" name="video_resolution_x">Video resolution in pixels horizontally</field>
+            <field type="uint16_t" name="video_resolution_y">Video resolution in pixels vertically</field>
         </message>
         <message id="263" name="CAMERA_IMAGE_CAPTURED">
             <description>Information about a captured image</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3779,7 +3779,7 @@
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
             <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>
-            <field type="float" name="image_framerate">Image interval capture in Hz</field>
+            <field type="float" name="image_interval">Image capture interval in Hz</field>
             <field type="float" name="video_framerate">Video frame rate in Hz</field>
             <field type="float" name="image_resolution">Resolution in megapixels</field>
             <field type="float" name="video_resolution">Resolution in megapixels</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1201,7 +1201,7 @@
                  <param index="6">Empty</param>
                  <param index="7">Empty</param>
                </entry>
-               
+
                <entry value="240" name="MAV_CMD_DO_LAST">
                     <description>NOP - This command is only used to mark the upper limit of the DO commands in the enumeration</description>
                     <param index="1">Empty</param>
@@ -1322,7 +1322,7 @@
                   <param index="1">Reserved</param>
                   <param index="2">Reserved</param>
               </entry>
-              
+
               <entry name="MAV_CMD_DO_TRIGGER_CONTROL" value="2003">
                    <description>Enable or disable on-board camera triggering system.</description>
                    <param index="1">Trigger enable/disable (0 for disable, 1 for start)</param>
@@ -1396,7 +1396,7 @@
                   <param index="7">Reserved</param>
               </entry>
               <!-- END of payload range (30000 to 30999) -->
-              
+
               <!-- BEGIN user defined range (31000 to 31999) -->
               <entry value="31000" name="MAV_CMD_WAYPOINT_USER_1">
                   <description>User defined waypoint item. Ground Station will show the Vehicle as flying through this item.</description>
@@ -1906,10 +1906,10 @@
               </entry>
               <entry value="25" name="MAV_SENSOR_ROTATION_PITCH_270">
                 <description>Roll: 0, Pitch: 270, Yaw: 0</description>
-              </entry>   
+              </entry>
               <entry value="26" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_90">
                 <description>Roll: 0, Pitch: 180, Yaw: 90</description>
-              </entry>  
+              </entry>
               <entry value="27" name="MAV_SENSOR_ROTATION_PITCH_180_YAW_270">
                   <description>Roll: 0, Pitch: 180, Yaw: 270</description>
               </entry>
@@ -3491,6 +3491,7 @@
             <field type="float" name="size_x">Size in radians of target along x-axis</field>
             <field type="float" name="size_y">Size in radians of target along y-axis</field>
         </message>
+
         <!-- MESSAGE IDs 180 - 229: Space for custom messages in individual projectname_messages.xml files -->
         <message id="230" name="ESTIMATOR_STATUS">
             <description>Estimator status message including flags, innovation test ratios and estimated accuracies. The flags message is an integer bitmask containing information on which EKF outputs are valid. See the ESTIMATOR_STATUS_FLAGS enum definition for further information. The innovaton test ratios show the magnitude of the sensor innovation divided by the innovation check threshold. Under normal operation the innovaton test ratios should be below 0.5 with occasional values up to 1.0. Values greater than 1.0 should be rare under normal operation and indicate that a measurement has been rejected by the filter. The user should be notified if an innovation test ratio greater than 1.0 is recorded. Notifications for values in the range between 0.5 and 1.0 should be optional and controllable by the user.</description>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1256,8 +1256,8 @@
                     <description>Request the reboot or shutdown of system components.</description>
                     <param index="1">0: Do nothing for autopilot, 1: Reboot autopilot, 2: Shutdown autopilot, 3: Reboot autopilot and keep it in the bootloader until upgraded.</param>
                     <param index="2">0: Do nothing for onboard computer, 1: Reboot onboard computer, 2: Shutdown onboard computer, 3: Reboot onboard computer and keep it in the bootloader until upgraded.</param>
-                    <param index="3">Reserved, send 0</param>
-                    <param index="4">Reserved, send 0</param>
+                    <param index="3">0: Do nothing for camera, 1: Reboot onboard camera, 2: Shutdown onboard camera, 3: Reboot onboard camera and keep it in the bootloader until upgraded</param>
+                    <param index="4">0: Do nothing for gimbal, 1: Reboot gimbal, 2: Shutdown gimbal, 3: Reboot gimbal and keep it in the bootloader until upgraded</param>
                     <param index="5">Reserved, send 0</param>
                     <param index="6">Reserved, send 0</param>
                     <param index="7">Reserved, send 0</param>
@@ -1310,6 +1310,40 @@
                  <param index="1">1: Request autopilot version</param>
                  <param index="2">Reserved (all remaining params)</param>
                </entry>
+               <entry value="521" name="MAV_CMD_REQUEST_CAMERA_INFORMATION">
+                 <description>Request camera information (CAMERA_INFORMATION)</description>
+                 <param index="1">1: Request camera capabilities</param>
+                 <param index="2">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="522" name="MAV_CMD_REQUEST_CAMERA_SETTINGS">
+                 <description>Request camera settings (CAMERA_SETTINGS)</description>
+                 <param index="1">1: Request camera settings</param>
+                 <param index="2">Camera ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="523" name="MAV_CMD_SET_CAMERA_SETTINGS">
+                 <description>Set the camera settings (CAMERA_SETTINGS)</description>
+                 <param index="1">Camera ID</param>
+                 <param index="2">Apertue (1/value, NaN for auto)</param>
+                 <param index="3">Shutter speed in s (NaN for auto)</param>
+                 <param index="4">ISO sensitivity (NaN for auto)</param>
+                 <param index="5">White balance (colour temperature in K, NaN for auto)</param>
+                 <param index="6">Reserved for camera mode ID</param>
+                 <param index="7">Reserved for image format ID</param>
+               </entry>
+               <entry value="524" name="MAV_CMD_REQUEST_STORAGE_INFORMATION">
+                 <description>Request storage information (STORAGE_INFORMATION)</description>
+                 <param index="1">1: Request storage information</param>
+                 <param index="2">Camera ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
+               </entry>
+               <entry value="525" name="MAV_CMD_STORAGE_FORMAT">
+                 <description>Format a storage medium</description>
+                 <param index="1">1: Format storage</param>
+                 <param index="2">Storage ID</param>
+                 <param index="3">Reserved (all remaining params)</param>
+               </entry>
+
               <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
                   <description>Start image capture sequence</description>
                   <param index="1">Duration between two consecutive pictures (in seconds)</param>
@@ -3685,6 +3719,44 @@
             <field name="target_component" type="uint8_t">Component ID</field>
             <field name="tune" type="char[30]">tune in board specific format</field>
           </message>
-          
-        </messages>
+
+        <message id="259" name="CAMERA_INFORMATION">
+            <description>Information about a camera</description>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple.</field>
+            <field type="uint8_t[16]" name="vendor_name">Name of the camera vendor</field>
+            <field type="uint8_t[16]" name="model_name">Name of the camera model</field>
+            <field type="float" name="focal_length">Focal length in mm</field>
+            <field type="float" name="sensor_size">Image sensor size in mm</field>
+            <field type="uint16_t" name="resolution_x">Image resolution in pixels horizontally</field>
+            <field type="uint16_t" name="resolution_y">Image resolution in pixels vertically</field>
+            <field type="uint8_t" name="lense_id">reserved for a lense ID</field>
+        </message>
+        <message id="260" name="CAMERA_SETTINGS">
+            <description>Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple.</field>
+            <field type="float" name="aperture">Aperture is 1/value</field>
+            <field type="float" name="shutter_speed">Shutter speed in s</field>
+            <field type="float" name="iso">ISO sensitivity</field>
+            <field type="float" name="white_balance">Color temperature in K</field>
+            <field type="uint8_t" name="mode_id">Reserved for a camera mode ID</field>
+            <field type="uint8_t" name="image_format_id">Reserved for image format ID</field>
+        </message>
+        <message id="261" name="STORAGE_INFORMATION">
+            <description>Information about a storage medium</description>
+            <field type="uint8_t" name="storage_id">Storage ID if there are multiple.</field>
+            <field type="uint8_t" name="status">Status of storage (0 not available, 1 unformatted, 2 formatted)</field>
+            <field type="float" name="total_capacity">Total capacity in MiB</field>
+            <field type="float" name="used_capacity">Used capacity in MiB</field>
+            <field type="float" name="available_capacity">Available capacity in MiB</field>
+            <field type="float" name="read_speed">Read speed in MiB/s</field>
+            <field type="float" name="write_speed">Write speed in MiB/s</field>
+        </message>
+        <message id="262" name="CAMERA_CAPTURE_STATUS">
+            <description>Information about a storage medium</description>
+            <field type="uint8_t" name="camera_id">Camera ID if there are multiple.</field>
+            <field type="uint8_t" name="image_status">Current status of image capturing (0: no action, 1: capture in progress, 2: capture completed)</field>
+            <field type="uint8_t" name="video_status">Current status of video capturing (0: no action, 1: capture in progress, 2: capture completed)</field>
+            <field type="uint8_t[128]" name="file_path">File path of current or last file.</field>
+        </message>
+    </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3748,6 +3748,7 @@
 
         <message id="259" name="CAMERA_INFORMATION">
             <description>Information about a camera</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
             <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
@@ -3760,6 +3761,7 @@
         </message>
         <message id="260" name="CAMERA_SETTINGS">
             <description>Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="float" name="aperture">Aperture is 1/value</field>
             <field type="uint8_t" name="aperture_locked">Aperture locked (0: auto, 1: locked)</field>
@@ -3775,6 +3777,7 @@
         </message>
         <message id="261" name="STORAGE_INFORMATION">
             <description>Information about a storage medium</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="storage_id">Storage ID if there are multiple</field>
             <field type="uint8_t" name="status">Status of storage (0 not available, 1 unformatted, 2 formatted)</field>
             <field type="float" name="total_capacity">Total capacity in MiB</field>
@@ -3785,6 +3788,7 @@
         </message>
         <message id="262" name="CAMERA_CAPTURE_STATUS">
             <description>Information about the status of a capture</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
             <field type="uint8_t" name="image_status">Current status of image capturing (0: not running, 1: interval capture in progress)</field>
             <field type="uint8_t" name="video_status">Current status of video capturing (0: not running, 1: capture in progress)</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3825,9 +3825,6 @@
             <description>Status and orientation of a mount</description>
                 <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
                <field type="uint8_t" name="mav_mount_mode">Mount operation mode (see MAV_MOUNT_MODE enum)</field>
-               <field type="uint8_t" name="roll_stabilized">Roll stabilized (1: yes, 0: no)</field>
-               <field type="uint8_t" name="pitch_stabilized">Pitch stabilized (1: yes, 0: no)</field>
-               <field type="uint8_t" name="yaw_stabilized">Yaw stabilized (1: yes, 0: no)</field>
                <field type="float" name="roll">Roll in degrees, set if appropriate mount mode.</field>
                <field type="float" name="pitch">Pitch in degrees, set if appropriate mount mode.</field>
                <field type="float" name="yaw">Yaw in degrees, set if appropriate mount mode.</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3740,8 +3740,8 @@
         <message id="259" name="CAMERA_INFORMATION">
             <description>Information about a camera</description>
             <field type="uint8_t" name="camera_id">Camera ID if there are multiple</field>
-            <field type="uint8_t[16]" name="vendor_name">Name of the camera vendor</field>
-            <field type="uint8_t[16]" name="model_name">Name of the camera model</field>
+            <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
+            <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
             <field type="float" name="focal_length">Focal length in mm</field>
             <field type="float" name="sensor_size">Image sensor size in mm</field>
             <field type="uint16_t" name="resolution_x">Image resolution in pixels horizontally</field>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3821,5 +3821,19 @@
             <field type="uint64_t" name="takeoff_time_utc">Timestamp at takeoff (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
             <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of logfiles</field>
         </message>
+        <message id="265" name="MOUNT_STATUS">
+            <description>Status and orientation of a mount</description>
+                <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+               <field type="uint8_t" name="mav_mount_mode">Mount operation mode (see MAV_MOUNT_MODE enum)</field>
+               <field type="uint8_t" name="roll_stabilized">Roll stabilized (1: yes, 0: no)</field>
+               <field type="uint8_t" name="pitch_stabilized">Pitch stabilized (1: yes, 0: no)</field>
+               <field type="uint8_t" name="yaw_stabilized">Yaw stabilized (1: yes, 0: no)</field>
+               <field type="float" name="roll">Roll in degrees, set if appropriate mount mode.</field>
+               <field type="float" name="pitch">Pitch in degrees, set if appropriate mount mode.</field>
+               <field type="float" name="yaw">Yaw in degrees, set if appropriate mount mode.</field>
+               <field type="int32_t" name="lat">Latitude, in degrees * 1E7, set if appropriate mount mode.</field>
+               <field type="int32_t" name="lon">Longitude, in degrees * 1E7, set if appropriate mount mode.</field>
+               <field type="float" name="alt">Altitude in meters, set if appropriate mount mode.</field>
+        </message>
     </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -1360,6 +1360,11 @@
                  <param index="2">Camera ID</param>
                  <param index="3">Reserved (all remaining params)</param>
                </entry>
+               <entry value="528" name="MAV_CMD_REQUEST_FLIGHT_INFORMATION">
+                 <description>Request flight information (FLIGHT_INFORMATION)</description>
+                 <param index="1">1: Request flight information</param>
+                 <param index="2">Reserved (all remaining params)</param>
+               </entry>
 
               <entry value="2000" name="MAV_CMD_IMAGE_START_CAPTURE">
                   <description>Start image capture sequence</description>
@@ -3804,6 +3809,13 @@
             <field type="float" name="q3">Quaternion component 3, y (0 in null-rotation) of camera direction</field>
             <field type="float" name="q4">Quaternion component 4, z (0 in null-rotation) of camera direction</field>
             <field type="uint8_t[210]" name="file_path">File path of image taken.</field>
+        </message>
+        <message id="264" name="FLIGHT_INFORMATION">
+            <description>Information about flight since last arming</description>
+            <field type="uint32_t" name="time_boot_ms">Timestamp (milliseconds since system boot)</field>
+            <field type="uint64_t" name="arming_time_utc">Timestamp at arming (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
+            <field type="uint64_t" name="takeoff_time_utc">Timestamp at takeoff (microseconds since UNIX epoch) in UTC, 0 for unknown</field>
+            <field type="uint64_t" name="flight_uuid">Universally unique identifier (UUID) of flight, should correspond to name of logfiles</field>
         </message>
     </messages>
 </mavlink>

--- a/message_definitions/v1.0/common.xml
+++ b/message_definitions/v1.0/common.xml
@@ -3743,10 +3743,11 @@
             <field type="uint8_t[32]" name="vendor_name">Name of the camera vendor</field>
             <field type="uint8_t[32]" name="model_name">Name of the camera model</field>
             <field type="float" name="focal_length">Focal length in mm</field>
-            <field type="float" name="sensor_size">Image sensor size in mm</field>
+            <field type="float" name="sensor_size_x">Image sensor size horizontally in mm</field>
+            <field type="float" name="sensor_size_y">Image sensor size vertically in mm</field>
             <field type="uint16_t" name="resolution_x">Image resolution in pixels horizontally</field>
             <field type="uint16_t" name="resolution_y">Image resolution in pixels vertically</field>
-            <field type="uint8_t" name="lense_id">reserved for a lense ID</field>
+            <field type="uint8_t" name="lense_id">Reserved for a lense ID</field>
         </message>
         <message id="260" name="CAMERA_SETTINGS">
             <description>Settings of a camera, can be requested using MAV_CMD_REQUEST_CAMERA_SETTINGS and written using MAV_CMD_SET_CAMERA_SETTINGS</description>


### PR DESCRIPTION
This is an attempt to improve and extend the mavlink camera and gimbal API.

The command `DIGICAM_CONFIGURE` is deprecated in favor of `CAMERA_INFORMATION`, `CAMERA_CAPTURE_STATUS`, `CAMERA_SETTINGS_1`, and `CAMERA_SETTINGS_2`.

For the camera storage `STORAGE_INFORMATION` and `STORAGE_FORMAT` has been added.

To control the gimbal, the lat/lon fields have been moved to param5/param6 for int32 accuracy, and a `MOUNT_STATUS` is added for the realtime feedback about a gimbal (or other mount).

Please review:
@LorenzMeier, @mcharleb
